### PR TITLE
[FIX] Fix import error on dask 2025.3.0

### DIFF
--- a/src/odc/loader/_builder.py
+++ b/src/odc/loader/_builder.py
@@ -27,7 +27,8 @@ import xarray as xr
 from dask import array as da
 from dask import is_dask_collection
 from dask.array.core import normalize_chunks
-from dask.base import quote, tokenize
+from dask.base import tokenize
+from dask.core import quote
 from dask.highlevelgraph import HighLevelGraph
 from dask.typing import Key
 from numpy.typing import DTypeLike


### PR DESCRIPTION
* Move `quote` import from `dask.base` to `dask.core`


Related Issue: https://github.com/dask/dask/issues/11843

