### PR TITLE
Remove unused type ignores

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ python_version = "3.10"
 ignore_missing_imports = true
 allow_redefinition = true
 show_error_codes = true
-
+warn_unused_ignores = true
 
 [tool.isort]
 profile = "black"

--- a/src/odc/loader/_builder.py
+++ b/src/odc/loader/_builder.py
@@ -477,7 +477,7 @@ def fuse_nd_slices(
         np.copyto(dst, fill_value)
 
     for yx_roi, pix in srcs:
-        _roi: tuple[slice, ...] = prefix_roi + yx_roi + postfix_roi  # type: ignore
+        _roi: tuple[slice, ...] = prefix_roi + yx_roi + postfix_roi
         assert dst[_roi].shape == pix.shape
 
         missing = nodata_mask(dst[_roi], fill_value)
@@ -738,7 +738,7 @@ def load_tasks(
         ydim = cfg.ydim + 1
 
         for idx in np.ndindex(shape_in_chunks[:3]):
-            tBi, yi, xi = idx  # type: ignore
+            tBi, yi, xi = idx
             srcs: List[List[int]] = []
             t0, nt = _offsets[0][tBi], _chunks[0][tBi]
             for ti in range(t0, t0 + nt):

--- a/src/odc/loader/_rio.py
+++ b/src/odc/loader/_rio.py
@@ -409,7 +409,7 @@ def _do_read(
     if dst is not None:
         # Assumes Y,X or B,Y,X order
         assert dst.ndim == ndim
-        _dst = dst[(...,) + roi_dst]  # type: ignore
+        _dst = dst[(...,) + roi_dst]
     else:
         shape = prefix + roi_shape(rr.roi_dst)
         _dst = np.ndarray(shape, dtype=resolve_dst_dtype(src.dtype, cfg))


### PR DESCRIPTION
Remove type ignores that are no longer used, and run mypy with `--warn-unused-ignores` to avoid this happening again.