### PR TITLE
Add override annotations

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,7 @@ python_version = "3.10"
 ignore_missing_imports = true
 allow_redefinition = true
 show_error_codes = true
+warn_redundant_casts = true
 warn_unused_ignores = true
 
 [tool.isort]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,7 @@ name = "odc.loader"
 python_version = "3.10"
 ignore_missing_imports = true
 allow_redefinition = true
+enable_error_code = ["explicit-override"]
 show_error_codes = true
 warn_redundant_casts = true
 warn_unused_ignores = true

--- a/src/odc/loader/_utils.py
+++ b/src/odc/loader/_utils.py
@@ -4,6 +4,7 @@ Generic tools with only standard lib dependencies.
 
 from concurrent.futures import ThreadPoolExecutor
 from typing import Callable, Iterable, Iterator, Sized, TypeVar, Union
+from typing_extensions import override
 
 T = TypeVar("T")
 S = TypeVar("S")
@@ -20,9 +21,11 @@ class SizedIterable(Sized, Iterable[T]):
         self._xx = iter(xx)
         self._n = n
 
+    @override
     def __len__(self) -> int:
         return self._n
 
+    @override
     def __iter__(self) -> Iterator[T]:
         yield from self._xx
 


### PR DESCRIPTION
This will enable MyPy to flag
methods that no longer override
their base class method when
refactoring the base class.

Also enable the MyPy warning for redundant casts.