### PR TITLE
Stop uploading to test pypi on every commit

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,30 +25,6 @@ jobs:
 
       - uses: hynek/build-and-inspect-python-package@v2
 
-  # Upload to Test PyPI on every commit on main.
-  release-test-pypi:
-    name: Publish in-dev package to test.pypi.org
-    environment: release-test-pypi
-    if: github.repository_owner == 'opendatacube' && github.event_name == 'push' && github.ref == 'refs/heads/main'
-    runs-on: ubuntu-latest
-    needs: build-package
-
-    permissions:
-      id-token: write
-
-    steps:
-      - name: Download packages built by build-and-inspect-python-package
-        uses: actions/download-artifact@v4
-        with:
-          name: Packages
-          path: dist
-
-      - name: Publish package to TestPyPI
-        # if: github.event_name == 'release'
-        uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          repository-url: https://test.pypi.org/legacy/
-
   # Upload to real PyPI on GitHub Releases.
   release-pypi:
     name: Publish released package to pypi.org


### PR DESCRIPTION
It made sense with dynamic versioning based on VCS tags to regularly test that packages pass being uploaded to testpypi. But since switching to manually incremented version numbers, it breaks every time.

Closes: #7