### PR TITLE
Add optional `.driver_data` to `{Raster,Aux}BandMetadata` classes 

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-version = "0.6.0rc1"
+version = "0.6.0rc2"
 name = "odc-loader"
 description = "Tooling for constructing xarray objects from parsed metadata"
 readme = "README.md"

--- a/src/odc/loader/__init__.py
+++ b/src/odc/loader/__init__.py
@@ -52,9 +52,10 @@ __all__ = (
 
 
 def __getattr__(name: str) -> str:
+    # pylint: disable=import-outside-toplevel
     from importlib.metadata import version
 
     if name == "__version__":
         return version("odc_loader")
-    else:
-        raise AttributeError(f"module {__name__} has no attribute {name}")
+
+    raise AttributeError(f"module {__name__} has no attribute {name}")

--- a/src/odc/loader/types.py
+++ b/src/odc/loader/types.py
@@ -70,6 +70,9 @@ class RasterBandMetadata:
     e.g. ("y", "x", "wavelength")
     """
 
+    driver_data: Any = None
+    """IO Driver specific extra data."""
+
     def with_defaults(self, defaults: "RasterBandMetadata") -> "RasterBandMetadata":
         """
         Merge with another metadata object, using self as the primary source.
@@ -81,6 +84,7 @@ class RasterBandMetadata:
             nodata=with_default(self.nodata, defaults.nodata),
             units=with_default(self.units, defaults.units, "1"),
             dims=with_default(self.dims, defaults.dims, ()),
+            driver_data=with_default(self.driver_data, defaults.driver_data),
         )
 
     def patch(self, **kwargs) -> "RasterBandMetadata":
@@ -101,6 +105,12 @@ class RasterBandMetadata:
             "nodata": _maybe_json(self.nodata),
             "units": self.units,
             "dims": self.dims,
+            "driver_data": _maybe_json(
+                self.driver_data,
+                allow_nan=False,
+                roundtrip=True,
+                on_error="SET, NOT JSON SERIALIZABLE",
+            ),
         }
 
     @property
@@ -156,6 +166,9 @@ class AuxBandMetadata:
     e.g. ("time",) or ("index",) or ()
     """
 
+    driver_data: Any = None
+    """IO Driver specific extra data."""
+
     def _repr_json_(self) -> Dict[str, Any]:
         """
         Return a JSON serializable representation of the AuxBandMetadata object.
@@ -165,6 +178,12 @@ class AuxBandMetadata:
             "nodata": _maybe_json(self.nodata),
             "units": self.units,
             "dims": self.dims,
+            "driver_data": _maybe_json(
+                self.driver_data,
+                allow_nan=False,
+                roundtrip=True,
+                on_error="SET, NOT JSON SERIALIZABLE",
+            ),
         }
 
     @property

--- a/src/odc/loader/types.py
+++ b/src/odc/loader/types.py
@@ -816,11 +816,12 @@ def _maybe_json(
         on_error = lambda _: "** NOT JSON SERIALIZABLE **"
 
     if not callable(on_error):
-        on_error = lambda _: on_error
+        error_value = on_error
+        on_error = lambda _: error_value
 
     try:
         json_txt = json.dumps(obj, allow_nan=allow_nan)
-    except ValueError:
+    except (ValueError, TypeError):
         return on_error(obj)
 
     if roundtrip:

--- a/uv.lock
+++ b/uv.lock
@@ -478,7 +478,7 @@ wheels = [
 
 [[package]]
 name = "odc-loader"
-version = "0.6.0rc1"
+version = "0.6.0rc2"
 source = { editable = "." }
 dependencies = [
     { name = "dask", extra = ["array"] },


### PR DESCRIPTION
This allows comms from parser to loader at the "structure level", i.e. before parsing any items with the band present.

## other fixes

* handle more cases of non-JSON-able data in `_maybe_json`
* `pylint` fixes in top level module
