### PR TITLE
CI: cancel previous jobs on PR updates

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,6 +7,12 @@ on:
 
 permissions: {}
 
+# When a PR is updated, cancel the jobs from the previous version. Merges
+# do not define head_ref, so use run_id to never cancel those jobs.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   quality:
     timeout-minutes: 15

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,6 +9,7 @@ permissions: {}
 
 jobs:
   quality:
+    timeout-minutes: 15
     runs-on: ubuntu-latest
     steps:
       - name: Check out
@@ -28,6 +29,7 @@ jobs:
         run: make check
 
   run-tests:
+    timeout-minutes: 15
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,12 @@ on:
       - published
   workflow_dispatch:
 
+# When a PR is updated, cancel the jobs from the previous version. Merges
+# do not define head_ref, so use run_id to never cancel those jobs.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   # Always build & lint package.
   build-package:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,7 @@ jobs:
   # Always build & lint package.
   build-package:
     name: Build & verify package
+    timeout-minutes: 15
     runs-on: ubuntu-latest
     permissions:
       id-token: write
@@ -28,6 +29,7 @@ jobs:
   # Upload to real PyPI on GitHub Releases.
   release-pypi:
     name: Publish released package to pypi.org
+    timeout-minutes: 15
     environment: release-pypi
     if: github.repository_owner == 'opendatacube' && github.event.action == 'published'
     runs-on: ubuntu-latest


### PR DESCRIPTION
This avoids clogging the CI machines when one of the quick checks fail and you update the PR to fix that.

Also add a commit that shortens the job timeout in case someone hangs the CI machines.