### PR TITLE
Fuser cfg resolve

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-version = "0.6.3"
+version = "0.6.4"
 name = "odc-loader"
 description = "Tooling for constructing xarray objects from parsed metadata"
 readme = "README.md"

--- a/src/odc/loader/_reader.py
+++ b/src/odc/loader/_reader.py
@@ -122,6 +122,7 @@ def resolve_load_cfg(
     use_overviews: bool = True,
     nodata: float | None = None,
     fail_on_error: bool = True,
+    fuse_func: str | Mapping[str, str | None] | None = None,
 ) -> dict[str, RasterLoadParams | AuxLoadParams]:
     """
     Combine band metadata with user provided settings to produce load configuration.
@@ -151,6 +152,11 @@ def resolve_load_cfg(
             return nodata
         return band.nodata
 
+    def _fuser(name: str, fuse_func: str | Mapping[str, str | None] | None) -> str | None:
+        if isinstance(fuse_func, Mapping):
+            return fuse_func.get(name, fuse_func.get("*", None))
+        return fuse_func
+
     def _resolve(
         name: str, meta: RasterBandMetadata | AuxBandMetadata
     ) -> RasterLoadParams | AuxLoadParams:
@@ -169,6 +175,7 @@ def resolve_load_cfg(
             fail_on_error=fail_on_error,
             dims=meta.dims,
             meta=meta,
+            fuser_fqn=_fuser(name, fuse_func)
         )
 
     return {name: _resolve(name, meta) for name, meta in bands.items()}

--- a/src/odc/loader/test_reader.py
+++ b/src/odc/loader/test_reader.py
@@ -417,12 +417,16 @@ def test_resolve_load_cfg() -> None:
         {
             "band": RasterBandMetadata("uint8", 255),
             "bb": RasterBandMetadata(),
+            "bc": RasterBandMetadata("uint8", 1),
             "aux": AuxBandMetadata("int16", -1),
         },
         resampling={"band": "bilinear", "*": "mode"},
+        fuse_func={"band": "a.b.c.fuser", "bb": None, "*": "d.e.f.fuser"},
     )
     assert "band" in cfg
     assert "aux" in cfg
+    assert "bb" in cfg
+    assert "bc" in cfg
 
     c = cfg["band"]
     assert isinstance(c, RasterLoadParams)
@@ -433,6 +437,7 @@ def test_resolve_load_cfg() -> None:
     assert c.src_nodata_fallback is None
     assert c.src_nodata_override is None
     assert c.fail_on_error is True
+    assert c.fuser_fqn == "a.b.c.fuser"
 
     c = cfg["bb"]
     assert isinstance(c, RasterLoadParams)
@@ -443,6 +448,18 @@ def test_resolve_load_cfg() -> None:
     assert c.src_nodata_fallback is None
     assert c.src_nodata_override is None
     assert c.fail_on_error is True
+    assert c.fuser_fqn is None
+
+    c = cfg["bc"]
+    assert isinstance(c, RasterLoadParams)
+    assert c.dtype == "uint8"
+    assert c.dims == ()
+    assert c.resampling == "mode"
+    assert c.fill_value == 1
+    assert c.src_nodata_fallback is None
+    assert c.src_nodata_override is None
+    assert c.fail_on_error is True
+    assert c.fuser_fqn == "d.e.f.fuser"
 
     c = cfg["aux"]
     assert isinstance(c, AuxLoadParams)

--- a/uv.lock
+++ b/uv.lock
@@ -422,7 +422,7 @@ name = "importlib-metadata"
 version = "8.7.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "zipp" },
+    { name = "zipp", marker = "python_full_version < '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/f3/49/3b30cad09e7771a4982d9975a8cbf64f00d4a1ececb53297f1d9a7be1b10/importlib_metadata-8.7.1.tar.gz", hash = "sha256:49fef1ae6440c182052f407c8d34a68f72efc36db9ca90dc0113398f2fdde8bb", size = 57107, upload-time = "2025-12-21T10:00:19.278Z" }
 wheels = [
@@ -838,7 +838,7 @@ wheels = [
 
 [[package]]
 name = "odc-loader"
-version = "0.6.3"
+version = "0.6.4"
 source = { editable = "." }
 dependencies = [
     { name = "dask", extra = ["array"] },


### PR DESCRIPTION
This PR modifies the `resolve_load_cfg()` function to process the `fuse_func` argument

`resolve_load_cfg()` is used by odc-stac to convert `odc.stac.load()` arguments to an odc-loader `LoadParams` dictionary.

Also bumps the version number for a 0.6.4 release.