### PR TITLE
STAC-provided nodata value used as a fallback when the GeoTIFF doesn't provide one

### DIFF
--- a/src/odc/loader/_reader.py
+++ b/src/odc/loader/_reader.py
@@ -170,7 +170,7 @@ def resolve_load_cfg(
         return RasterLoadParams(
             _dtype(name, meta.data_type, "float32"),
             fill_value=_fill_value(meta),
-            src_nodata_fallback=_fill_value(meta),
+            src_nodata_fallback=meta.nodata,
             use_overviews=use_overviews,
             resampling=_resampling(name, "nearest"),
             fail_on_error=fail_on_error,

--- a/src/odc/loader/_reader.py
+++ b/src/odc/loader/_reader.py
@@ -170,6 +170,7 @@ def resolve_load_cfg(
         return RasterLoadParams(
             _dtype(name, meta.data_type, "float32"),
             fill_value=_fill_value(meta),
+            src_nodata_fallback=_fill_value(meta),
             use_overviews=use_overviews,
             resampling=_resampling(name, "nearest"),
             fail_on_error=fail_on_error,

--- a/src/odc/loader/test_reader.py
+++ b/src/odc/loader/test_reader.py
@@ -478,3 +478,85 @@ def test_rio_driver_init() -> None:
     assert driver.md_parser is a
     assert driver.aux_reader is b
     assert driver.dask_reader is c
+
+
+def test_src_nodata_fallback_fuse_adjacent_scenes() -> None:
+    """
+    When two scenes are warped to a different CRS and fused, fill pixels
+    (matching the nodata value) from one scene must not block real data
+    from the other scene in the overlap zone.
+
+    This requires src_nodata_fallback to be set so that rasterio.warp.reproject
+    knows to treat the fill value as nodata in the source, even when the
+    GeoTIFF file itself has no nodata tag.
+
+    Regression test for https://github.com/opendatacube/odc-stac/issues/259
+    """
+    from ._fuser import fuser_for_nodata
+
+    FILL = 1
+    DATA_A = 100
+    DATA_B = 200
+
+    # Two overlapping source scenes in EPSG:32630 (UTM 30N)
+    gbox_a = GeoBox.from_bbox(
+        (166000, 0, 566000, 500000), crs="EPSG:32630", resolution=10000
+    )
+    gbox_b = GeoBox.from_bbox(
+        (366000, 0, 834000, 500000), crs="EPSG:32630", resolution=10000
+    )
+
+    # Destination in EPSG:4326 to force the reproject codepath
+    a_4326 = gbox_a.extent.to_crs("EPSG:4326").boundingbox
+    b_4326 = gbox_b.extent.to_crs("EPSG:4326").boundingbox
+    dst_gbox = GeoBox.from_bbox(
+        (
+            min(a_4326.left, b_4326.left),
+            min(a_4326.bottom, b_4326.bottom),
+            max(a_4326.right, b_4326.right),
+            max(a_4326.top, b_4326.top),
+        ),
+        crs="EPSG:4326",
+        resolution=0.1,
+    )
+
+    # Scene A: real data, except fill on the right (the overlap zone)
+    src_a = xr_zeros(gbox_a, dtype="uint16")
+    src_a.values[:] = DATA_A
+    src_a.values[:, 28:] = FILL
+
+    # Scene B: fill on the left (overlap zone), real data on the right
+    src_b = xr_zeros(gbox_b, dtype="uint16")
+    src_b.values[:] = DATA_B
+    src_b.values[:, :15] = FILL
+
+    # Use resolve_load_cfg with band metadata that has nodata set (as STAC
+    # raster:bands would provide). This exercises the fix: resolve_load_cfg
+    # now sets src_nodata_fallback from meta.nodata so rasterio.warp.reproject
+    # knows to treat fill pixels as nodata in the source.
+    band_meta = RasterBandMetadata(data_type="uint16", nodata=FILL)
+    load_cfg = resolve_load_cfg({"qa_pixel": band_meta})
+    cfg = load_cfg["qa_pixel"]
+    assert cfg.fill_value == FILL
+    assert cfg.src_nodata_fallback == FILL
+
+    mosaic = np.full(dst_gbox.shape, FILL, dtype="uint16")
+    fuser = fuser_for_nodata(FILL)
+
+    for src_data in [src_a, src_b]:
+        with with_temp_tiff(src_data, compress=None, overview_levels=[]) as uri:
+            src = RasterSource(uri)
+            roi, pix = rio_read(src, cfg, dst_gbox)
+            if pix.size > 0:
+                fuser(mosaic[roi], pix)
+
+    data_a_count = int((mosaic == DATA_A).sum())
+    data_b_count = int((mosaic == DATA_B).sum())
+
+    # Both scenes contribute their real data to the mosaic
+    assert data_a_count > 0, "Scene A data should be present"
+    assert data_b_count > 0, "Scene B data should be present"
+
+    # No spurious zeros: src_nodata_fallback ensures reproject uses FILL as
+    # both src and dst nodata, so outside-of-source regions get FILL not 0
+    assert int((mosaic == 0).sum()) == 0, "No zeros should appear in the mosaic"

--- a/src/odc/loader/test_reader.py
+++ b/src/odc/loader/test_reader.py
@@ -537,6 +537,7 @@ def test_src_nodata_fallback_fuse_adjacent_scenes() -> None:
     band_meta = RasterBandMetadata(data_type="uint16", nodata=FILL)
     load_cfg = resolve_load_cfg({"qa_pixel": band_meta})
     cfg = load_cfg["qa_pixel"]
+    assert isinstance(cfg, RasterLoadParams)
     assert cfg.fill_value == FILL
     assert cfg.src_nodata_fallback == FILL
 

--- a/src/odc/loader/test_reader.py
+++ b/src/odc/loader/test_reader.py
@@ -434,7 +434,7 @@ def test_resolve_load_cfg() -> None:
     assert c.dims == ()
     assert c.resampling == "bilinear"
     assert c.fill_value == 255
-    assert c.src_nodata_fallback is None
+    assert c.src_nodata_fallback == 255
     assert c.src_nodata_override is None
     assert c.fail_on_error is True
     assert c.fuser_fqn == "a.b.c.fuser"
@@ -456,7 +456,7 @@ def test_resolve_load_cfg() -> None:
     assert c.dims == ()
     assert c.resampling == "mode"
     assert c.fill_value == 1
-    assert c.src_nodata_fallback is None
+    assert c.src_nodata_fallback == 1
     assert c.src_nodata_override is None
     assert c.fail_on_error is True
     assert c.fuser_fqn == "d.e.f.fuser"

--- a/uv.lock
+++ b/uv.lock
@@ -422,7 +422,7 @@ name = "importlib-metadata"
 version = "8.7.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "zipp", marker = "python_full_version < '3.12'" },
+    { name = "zipp" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/f3/49/3b30cad09e7771a4982d9975a8cbf64f00d4a1ececb53297f1d9a7be1b10/importlib_metadata-8.7.1.tar.gz", hash = "sha256:49fef1ae6440c182052f407c8d34a68f72efc36db9ca90dc0113398f2fdde8bb", size = 57107, upload-time = "2025-12-21T10:00:19.278Z" }
 wheels = [


### PR DESCRIPTION
See bug in reported in `odc-stac` https://github.com/opendatacube/odc-stac/issues/259

The issue is that resolve_load_cfg sets `fill_value` from STAC metadata (nodata=1 for Landsat's qa_pixel), but leaves src_nodata_fallback=None. When _do_read calls `rasterio.warp.reproject`, it reads the source file's nodata tag (rdr.nodatavals → None for Landsat QA_PIXEL GeoTIFFs). With src_nodata=None, GDAL treats fill pixels as valid data, so they get warped into the output and block the fuser from using real data from the overlapping scene.

Edit to emphasise that this fix resolves a regression in behaviour between Rasterio/GDAL `1.5.0/3.12.2` and `1.4.3/3.9.x` 