### PR TITLE
Update with Python 3.10 features

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,4 +81,5 @@ dev = [
 [tool.ruff.lint]
 select = [
     "I",  # Isort
+    "UP", # pyupgrade
 ]

--- a/src/odc/loader/_aws.py
+++ b/src/odc/loader/_aws.py
@@ -9,7 +9,7 @@ Helper methods for working with AWS
 import json
 import os
 import time
-from typing import Any, Dict, Optional, Tuple
+from typing import Any
 from urllib.request import urlopen
 
 import botocore
@@ -28,7 +28,7 @@ __all__ = (
 )
 
 
-def _fetch_text(url: str, timeout: float = 0.1) -> Optional[str]:
+def _fetch_text(url: str, timeout: float = 0.1) -> str | None:
     try:
         with urlopen(url, timeout=timeout) as resp:
             if 200 <= resp.getcode() < 300:
@@ -38,7 +38,7 @@ def _fetch_text(url: str, timeout: float = 0.1) -> Optional[str]:
         return None
 
 
-def ec2_metadata(timeout: float = 0.1) -> Optional[Dict[str, Any]]:
+def ec2_metadata(timeout: float = 0.1) -> dict[str, Any] | None:
     """
     Grab EC2 instance metadata.
 
@@ -59,7 +59,7 @@ def ec2_metadata(timeout: float = 0.1) -> Optional[Dict[str, Any]]:
         return None
 
 
-def ec2_current_region() -> Optional[str]:
+def ec2_current_region() -> str | None:
     """Returns name of the region  this EC2 instance is running in."""
     cfg = ec2_metadata()
     if cfg is None:
@@ -67,16 +67,14 @@ def ec2_current_region() -> Optional[str]:
     return cfg.get("region", None)
 
 
-def botocore_default_region(session: Optional[Session] = None) -> Optional[str]:
+def botocore_default_region(session: Session | None = None) -> str | None:
     """Returns default region name as configured on the system."""
     if session is None:
         session = botocore.session.get_session()
     return session.get_config_variable("region")
 
 
-def auto_find_region(
-    session: Optional[Session] = None, default: Optional[str] = None
-) -> str:
+def auto_find_region(session: Session | None = None, default: str | None = None) -> str:
     """
     Try to figure out which region name to use
 
@@ -101,7 +99,7 @@ def auto_find_region(
 
 def get_creds_with_retry(
     session: Session, max_tries: int = 10, sleep: float = 0.1
-) -> Optional[Credentials]:
+) -> Credentials | None:
     """Attempt to obtain credentials upto `max_tries` times with back off
     :param session: botocore session, see mk_boto_session
     :param max_tries: number of attempt before failing and returing None
@@ -120,9 +118,9 @@ def get_creds_with_retry(
 
 
 def mk_boto_session(
-    profile: Optional[str] = None,
-    creds: Optional[ReadOnlyCredentials] = None,
-    region_name: Optional[str] = None,
+    profile: str | None = None,
+    creds: ReadOnlyCredentials | None = None,
+    region_name: str | None = None,
 ) -> Session:
     """Get botocore session with correct `region` configured
 
@@ -159,11 +157,11 @@ def aws_unsigned_check_env() -> bool:
 
 
 def get_aws_settings(
-    profile: Optional[str] = None,
+    profile: str | None = None,
     region_name: str = "auto",
-    aws_unsigned: Optional[bool] = None,
+    aws_unsigned: bool | None = None,
     requester_pays: bool = False,
-) -> Tuple[Dict[str, Any], Credentials | None]:
+) -> tuple[dict[str, Any], Credentials | None]:
     """
     Compute ``aws=`` parameter for ``set_default_rio_config``.
 

--- a/src/odc/loader/_aws.py
+++ b/src/odc/loader/_aws.py
@@ -34,7 +34,7 @@ def _fetch_text(url: str, timeout: float = 0.1) -> Optional[str]:
             if 200 <= resp.getcode() < 300:
                 return resp.read().decode("utf8")
             return None
-    except IOError:
+    except OSError:
         return None
 
 

--- a/src/odc/loader/_builder.py
+++ b/src/odc/loader/_builder.py
@@ -5,25 +5,11 @@ from __future__ import annotations
 
 import dataclasses
 import os
+from collections.abc import Hashable, Iterable, Iterator, Mapping, Sequence
 from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime
 from types import SimpleNamespace
-from typing import (
-    Any,
-    Dict,
-    Hashable,
-    Iterable,
-    Iterator,
-    List,
-    Literal,
-    Mapping,
-    Optional,
-    Protocol,
-    Sequence,
-    Tuple,
-    TypeAlias,
-    cast,
-)
+from typing import Any, Literal, Protocol, TypeAlias, cast
 
 import dask
 import numpy as np
@@ -94,7 +80,7 @@ class MkArray(Protocol):
     # pylint: disable=too-few-public-methods
     def __call__(
         self,
-        shape: Tuple[int, ...],
+        shape: tuple[int, ...],
         dtype: DTypeLike,
         /,
         name: Hashable,
@@ -111,16 +97,16 @@ class LoadChunkTask:
     # pylint: disable=too-many-instance-attributes
 
     band: str
-    srcs: List[List[int]]
+    srcs: list[list[int]]
     cfg: RasterLoadParams
     gbt: GeoboxTiles
-    idx: Tuple[int, ...]
-    shape: Tuple[int, ...]
+    idx: tuple[int, ...]
+    shape: tuple[int, ...]
     ydim: int = 1
     selection: ReaderSubsetSelection | None = None  # optional slice into extra dims
 
     @property
-    def idx_tyx(self) -> Tuple[int, int, int]:
+    def idx_tyx(self) -> tuple[int, int, int]:
         ydim = self.ydim
         return self.idx[0], self.idx[ydim], self.idx[ydim + 1]
 
@@ -133,7 +119,7 @@ class LoadChunkTask:
         return self.shape[self.ydim + 2 :]
 
     @property
-    def dst_roi(self) -> Tuple[slice, ...]:
+    def dst_roi(self) -> tuple[slice, ...]:
         t, y, x = self.idx_tyx
         iy, ix = self.gbt.roi[y, x]
         return (
@@ -154,11 +140,11 @@ class LoadChunkTask:
 
     def resolve_sources(
         self, srcs: Sequence[MultiBandSource]
-    ) -> List[List[tuple[int, RasterSource]]]:
-        out: List[List[tuple[int, RasterSource]]] = []
+    ) -> list[list[tuple[int, RasterSource]]]:
+        out: list[list[tuple[int, RasterSource]]] = []
 
         for layer in self.srcs:
-            _srcs: List[tuple[int, RasterSource]] = []
+            _srcs: list[tuple[int, RasterSource]] = []
             for idx in layer:
                 src = srcs[idx].get(self.band, None)
                 if src is not None and isinstance(src, RasterSource):
@@ -213,9 +199,9 @@ class DaskGraphBuilder:
         cfg: Mapping[str, RasterLoadParams],
         template: RasterGroupMetadata,
         srcs: Sequence[MultiBandSource],
-        tyx_bins: Mapping[Tuple[int, int, int], List[int]],
+        tyx_bins: Mapping[tuple[int, int, int], list[int]],
         gbt: GeoboxTiles,
-        env: Dict[str, Any],
+        env: dict[str, Any],
         rdr: ReaderDriver,
         chunks: Mapping[str, int],
         mode: DaskBuilderMode | Literal["auto"] = "auto",
@@ -351,7 +337,7 @@ class DaskGraphBuilder:
 
     def __call__(
         self,
-        shape: Tuple[int, ...],
+        shape: tuple[int, ...],
         dtype: DTypeLike,
         /,
         name: Hashable,
@@ -375,7 +361,7 @@ class DaskGraphBuilder:
             f"{name}-{tk}",
         )
 
-        layers: Dict[str, Dict[Key, Any]] = {
+        layers: dict[str, dict[Key, Any]] = {
             cfg_layer: {
                 cfg_dsk: cfg,
                 gbt_dsk: self.gbt,
@@ -383,7 +369,7 @@ class DaskGraphBuilder:
             open_layer: {},
             band_layer: {},
         }
-        layer_deps: Dict[str, Any] = {
+        layer_deps: dict[str, Any] = {
             cfg_layer: set(),
             open_layer: set([cfg_layer]),
             band_layer: set([cfg_layer, open_layer]),
@@ -468,7 +454,7 @@ class DaskGraphBuilder:
 def _dask_open_reader(
     src: RasterSource,
     rdr: ReaderDriver,
-    env: Dict[str, Any],
+    env: dict[str, Any],
     load_state: GlobalLoadContext,
 ) -> RasterReader:
     with rdr.restore_env(env, load_state) as ctx:
@@ -478,12 +464,12 @@ def _dask_open_reader(
 def _dask_loader_tyx(
     srcs: Sequence[Sequence[RasterReader]],
     gbt: GeoboxTiles,
-    iyx: Tuple[int, int],
-    prefix_dims: Tuple[int, ...],
-    postfix_dims: Tuple[int, ...],
+    iyx: tuple[int, int],
+    prefix_dims: tuple[int, ...],
+    postfix_dims: tuple[int, ...],
     cfg: RasterLoadParams,
     rdr: ReaderDriver,
-    env: Dict[str, Any],
+    env: dict[str, Any],
     load_state: GlobalLoadContext,
     selection: Any | None = None,
 ) -> np.ndarray[tuple[int, ...]]:
@@ -595,7 +581,7 @@ def mk_dataset(
     gbox: GeoBox,
     time: Sequence[datetime],
     bands: Mapping[str, RasterLoadParams],
-    alloc: Optional[MkArray] = None,
+    alloc: MkArray | None = None,
     *,
     template: RasterGroupMetadata,
 ) -> xr.Dataset:
@@ -613,7 +599,7 @@ def mk_dataset(
         for coord in template.extra_coords
     }
 
-    def _alloc(shape: Tuple[int, ...], dtype: str, name: Hashable, ydim: int) -> Any:
+    def _alloc(shape: tuple[int, ...], dtype: str, name: Hashable, ydim: int) -> Any:
         if alloc is not None:
             return alloc(shape, dtype, name=name, ydim=ydim)
         return np.empty(shape, dtype=dtype)
@@ -628,13 +614,13 @@ def mk_dataset(
             prefix_dims = band.dims[:ydim]
             postfix_dims = band.dims[ydim + 2 :]
 
-            dims: Tuple[str, ...] = (
+            dims: tuple[str, ...] = (
                 "time",
                 *prefix_dims,
                 *gbox.dimensions,
                 *postfix_dims,
             )
-            shape: Tuple[int, ...] = (
+            shape: tuple[int, ...] = (
                 len(time),
                 *[_dims[dim] for dim in prefix_dims],
                 *gbox.shape.yx,
@@ -677,16 +663,16 @@ def chunked_load(
     load_cfg: Mapping[str, RasterLoadParams | AuxLoadParams],
     template: RasterGroupMetadata,
     srcs: Sequence[MultiBandSource],
-    tyx_bins: Mapping[Tuple[int, int, int], List[int]],
+    tyx_bins: Mapping[tuple[int, int, int], list[int]],
     gbt: GeoboxTiles,
     tss: Sequence[datetime],
-    env: Dict[str, Any],
+    env: dict[str, Any],
     rdr: ReaderDriver,
     *,
     dtype: Band_DType | None = None,
     chunks: Mapping[str, int | Literal["auto"]] | None = None,
     pool: ThreadPoolExecutor | int | None = None,
-    progress: Optional[Any] = None,
+    progress: Any | None = None,
 ) -> xr.Dataset:
     """
     Route to either direct or dask chunked load.
@@ -723,10 +709,10 @@ def dask_chunked_load(
     load_cfg: Mapping[str, RasterLoadParams | AuxLoadParams],
     template: RasterGroupMetadata,
     srcs: Sequence[MultiBandSource],
-    tyx_bins: Mapping[Tuple[int, int, int], List[int]],
+    tyx_bins: Mapping[tuple[int, int, int], list[int]],
     gbt: GeoboxTiles,
     tss: Sequence[datetime],
-    env: Dict[str, Any],
+    env: dict[str, Any],
     rdr: ReaderDriver,
     *,
     dtype: Band_DType | None = None,
@@ -786,10 +772,10 @@ def denorm_ydim(x: tuple[T, ...], ydim: int) -> tuple[T, ...]:
 
 def load_tasks(
     load_cfg: Mapping[str, RasterLoadParams],
-    tyx_bins: Mapping[Tuple[int, int, int], List[int]],
+    tyx_bins: Mapping[tuple[int, int, int], list[int]],
     gbt: GeoboxTiles,
     *,
-    nt: Optional[int] = None,
+    nt: int | None = None,
     chunks: Mapping[str, int] | None = None,
     extra_dims: Mapping[str, int] | None = None,
     bands: Sequence[str] | None = None,
@@ -831,7 +817,7 @@ def load_tasks(
 
         for idx in np.ndindex(shape_in_chunks[:3]):
             tBi, yi, xi = idx
-            srcs: List[List[int]] = []
+            srcs: list[list[int]] = []
             t0, nt = _offsets[0][tBi], _chunks[0][tBi]
             for ti in range(t0, t0 + nt):
                 tyx_idx = (ti, yi, xi)
@@ -895,14 +881,14 @@ def direct_chunked_load(
     load_cfg: Mapping[str, RasterLoadParams | AuxLoadParams],
     template: RasterGroupMetadata,
     srcs: Sequence[MultiBandSource],
-    tyx_bins: Mapping[Tuple[int, int, int], List[int]],
+    tyx_bins: Mapping[tuple[int, int, int], list[int]],
     gbt: GeoboxTiles,
     tss: Sequence[datetime],
-    env: Dict[str, Any],
+    env: dict[str, Any],
     rdr: ReaderDriver,
     *,
     pool: ThreadPoolExecutor | int | None = None,
-    progress: Optional[Any] = None,
+    progress: Any | None = None,
 ) -> xr.Dataset:
     """
     Load in chunks but without using Dask.
@@ -923,7 +909,7 @@ def direct_chunked_load(
     total_tasks = nt * nb * ny * nx
     load_state = rdr.new_load(gbox)
 
-    def _do_one(task: LoadChunkTask) -> Tuple[str, int, int, int]:
+    def _do_one(task: LoadChunkTask) -> tuple[str, int, int, int]:
         dst_slice = ds[task.band].data[task.dst_roi]
         layers = task.resolve_sources(srcs)
         ydim = len(task.prefix_dims)
@@ -1006,7 +992,7 @@ def resolve_chunks(
         extra_dims = {}
     tt = chunks.get("time", 1)
     ty, tx = (chunks.get(dim, -1) for dim in ["y", "x"])
-    chunks = (tt, ty, tx) + tuple((chunks.get(dim, -1) for dim in extra_dims))
+    chunks = (tt, ty, tx) + tuple(chunks.get(dim, -1) for dim in extra_dims)
     shape = base_shape + tuple(extra_dims.values())
     return normalize_chunks(chunks, shape, dtype=dtype, limit=limit)
 
@@ -1018,7 +1004,7 @@ def resolve_chunk_shape(
     dtype: Any | None = None,
     cfg: Mapping[str, RasterLoadParams | AuxLoadParams] | None = None,
     extra_dims: Mapping[str, int] | None = None,
-) -> Tuple[int, ...]:
+) -> tuple[int, ...]:
     """
     Compute chunk size for time, y and x dimensions and extra dims for raster
     bands only.
@@ -1058,7 +1044,7 @@ def _used_names(ds: xr.Dataset) -> set[str]:
 def _add_aux_bands(
     ds: xr.Dataset,
     aux_cfg: Mapping[str, AuxLoadParams],
-    tyx_bins: Mapping[Tuple[int, int, int], List[int]],
+    tyx_bins: Mapping[tuple[int, int, int], list[int]],
     srcs: Sequence[MultiBandSource],
     rdr: ReaderDriver,
     ctx: GlobalLoadContext,

--- a/src/odc/loader/_dask.py
+++ b/src/odc/loader/_dask.py
@@ -2,16 +2,8 @@
 Various Dask helpers.
 """
 
-from collections.abc import Generator, Iterable
-from typing import (
-    Any,
-    Callable,
-    Hashable,
-    MutableMapping,
-    Optional,
-    Tuple,
-    TypeVar,
-)
+from collections.abc import Callable, Generator, Hashable, Iterable, MutableMapping
+from typing import Any, TypeVar
 
 from dask.base import tokenize
 
@@ -20,9 +12,9 @@ T = TypeVar("T")
 
 def tokenize_stream(
     xx: Iterable[T],
-    key: Optional[Callable[[str], Hashable]] = None,
-    dsk: Optional[MutableMapping[Hashable, Any]] = None,
-) -> Generator[Tuple[Hashable, T]]:
+    key: Callable[[str], Hashable] | None = None,
+    dsk: MutableMapping[Hashable, Any] | None = None,
+) -> Generator[tuple[Hashable, T]]:
     if key:
         kx = ((key(tokenize(x)), x) for x in xx)
     else:

--- a/src/odc/loader/_driver.py
+++ b/src/odc/loader/_driver.py
@@ -6,8 +6,9 @@ Currently always goes to rasterio
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from importlib import import_module
-from typing import Any, Callable
+from typing import Any
 
 from ._rio import RioDriver
 from ._zarr import XrMemReaderDriver

--- a/src/odc/loader/_reader.py
+++ b/src/odc/loader/_reader.py
@@ -8,7 +8,8 @@ Utilities for reading pixels from raster files.
 from __future__ import annotations
 
 import math
-from typing import Any, Mapping, Optional, Sequence
+from collections.abc import Mapping, Sequence
+from typing import Any
 
 import numpy as np
 from dask import delayed
@@ -35,7 +36,7 @@ def _dask_read_adaptor(
     dst_geobox: GeoBox,
     driver: ReaderDriver,
     env: dict[str, Any],
-    selection: Optional[ReaderSubsetSelection] = None,
+    selection: ReaderSubsetSelection | None = None,
 ) -> tuple[tuple[slice, slice], np.ndarray]:
 
     with driver.restore_env(env, ctx) as local_ctx:
@@ -75,7 +76,7 @@ class ReaderDaskAdaptor:
         self,
         dst_geobox: GeoBox,
         *,
-        selection: Optional[ReaderSubsetSelection] = None,
+        selection: ReaderSubsetSelection | None = None,
         idx: tuple[int, ...],
     ) -> Any:
         assert self._src is not None
@@ -103,7 +104,7 @@ class ReaderDaskAdaptor:
         ctx: GlobalLoadContext,
         layer_name: str,
         idx: int,
-    ) -> "ReaderDaskAdaptor":
+    ) -> ReaderDaskAdaptor:
         return ReaderDaskAdaptor(
             self._driver,
             self._env,
@@ -183,9 +184,7 @@ def resolve_load_cfg(
     return {name: _resolve(name, meta) for name, meta in bands.items()}
 
 
-def resolve_src_nodata(
-    nodata: Optional[float], cfg: RasterLoadParams
-) -> Optional[float]:
+def resolve_src_nodata(nodata: float | None, cfg: RasterLoadParams) -> float | None:
     if cfg.src_nodata_override is not None:
         return cfg.src_nodata_override
     if nodata is not None:
@@ -202,8 +201,8 @@ def resolve_dst_dtype(src_dtype: str, cfg: RasterLoadParams) -> np.dtype:
 def resolve_dst_nodata(
     dst_dtype: np.dtype,
     cfg: RasterLoadParams,
-    src_nodata: Optional[float] = None,
-) -> Optional[float]:
+    src_nodata: float | None = None,
+) -> float | None:
     # 1. Configuration
     # 2. np.nan for float32 outputs
     # 3. Fall back to source nodata
@@ -222,7 +221,7 @@ def resolve_dst_nodata(
 def resolve_dst_fill_value(
     dst_dtype: np.dtype,
     cfg: RasterLoadParams,
-    src_nodata: Optional[float] = None,
+    src_nodata: float | None = None,
 ) -> float:
     nodata = resolve_dst_nodata(dst_dtype, cfg, src_nodata)
     if nodata is None:
@@ -281,7 +280,7 @@ def expand_selection(selection: Any, ydim: int) -> tuple[slice, ...]:
     return prefix + (slice(None), slice(None)) + postfix
 
 
-def pick_overview(read_shrink: int, overviews: Sequence[int]) -> Optional[int]:
+def pick_overview(read_shrink: int, overviews: Sequence[int]) -> int | None:
     if len(overviews) == 0 or read_shrink < overviews[0]:
         return None
 
@@ -294,7 +293,7 @@ def pick_overview(read_shrink: int, overviews: Sequence[int]) -> Optional[int]:
     return _idx
 
 
-def same_nodata(a: Optional[float], b: Optional[float]) -> bool:
+def same_nodata(a: float | None, b: float | None) -> bool:
     if a is None:
         return b is None
     if b is None:
@@ -304,7 +303,7 @@ def same_nodata(a: Optional[float], b: Optional[float]) -> bool:
     return a == b
 
 
-def nodata_mask(pix: np.ndarray, nodata: Optional[float]) -> np.ndarray:
+def nodata_mask(pix: np.ndarray, nodata: float | None) -> np.ndarray:
     if pix.dtype.kind == "f":
         if nodata is None or math.isnan(nodata):
             return np.isnan(pix)

--- a/src/odc/loader/_rio.py
+++ b/src/odc/loader/_rio.py
@@ -10,8 +10,9 @@ from __future__ import annotations
 
 import logging
 import threading
+from collections.abc import Iterator
 from contextlib import contextmanager
-from typing import TYPE_CHECKING, Any, Dict, Iterator, Optional, Union
+from typing import TYPE_CHECKING, Any
 
 import numpy as np
 import rasterio
@@ -103,7 +104,7 @@ class GlobalContext:
     Shared across all Readers for single ``.load``.
     """
 
-    def __init__(self, geobox: GeoBox, chunks: Dict[str, int] | None = None) -> None:
+    def __init__(self, geobox: GeoBox, chunks: dict[str, int] | None = None) -> None:
         self.geobox = geobox
         self.chunks = chunks
         self._local_ctx: Any | None = None
@@ -139,8 +140,8 @@ class RioReader:
         cfg: RasterLoadParams,
         dst_geobox: GeoBox,
         *,
-        dst: Optional[np.ndarray] = None,
-        selection: Optional[ReaderSubsetSelection] = None,
+        dst: np.ndarray | None = None,
+        selection: ReaderSubsetSelection | None = None,
     ) -> tuple[tuple[slice, slice], np.ndarray]:
         return rio_read(self._src, cfg, dst_geobox, dst=dst, selection=selection)
 
@@ -166,19 +167,19 @@ class RioDriver:
         self,
         geobox: GeoBox,
         *,
-        chunks: None | Dict[str, int] = None,
+        chunks: None | dict[str, int] = None,
     ) -> GlobalContext:
         return GlobalContext(geobox, chunks=chunks)
 
     def finalise_load(self, load_state: GlobalContext) -> Any:
         return load_state.finalise()
 
-    def capture_env(self) -> Dict[str, Any]:
+    def capture_env(self) -> dict[str, Any]:
         return capture_rio_env()
 
     @contextmanager
     def restore_env(
-        self, env: Dict[str, Any], load_state: GlobalContext
+        self, env: dict[str, Any], load_state: GlobalContext
     ) -> Iterator[LocalContext]:
         with rio_env(**env):
             yield load_state.local_ctx(LocalContext)
@@ -206,14 +207,14 @@ class RioDriver:
 class _GlobalRioConfig:
     def __init__(self) -> None:
         self._configured = False
-        self._aws: Optional[Dict[str, Any]] = None
-        self._gdal_opts: Dict[str, Any] = {}
+        self._aws: dict[str, Any] | None = None
+        self._gdal_opts: dict[str, Any] = {}
 
     def set(
         self,
         *,
-        aws: Optional[Dict[str, Any]],
-        gdal_opts: Dict[str, Any],
+        aws: dict[str, Any] | None,
+        gdal_opts: dict[str, Any],
     ) -> None:
         self._aws = {**aws} if aws is not None else None
         self._gdal_opts = {**gdal_opts}
@@ -227,7 +228,7 @@ class _GlobalRioConfig:
         if self._configured is False:
             return rasterio.env.Env(_local.session())
 
-        session: Optional[Session] = None
+        session: Session | None = None
         if self._aws is not None:
             session = AWSSession(**self._aws)
         return rasterio.env.Env(_local.session(session), **self._gdal_opts)
@@ -243,8 +244,8 @@ class ThreadSession(threading.local):
 
     def __init__(self) -> None:
         super().__init__()
-        self._session: Optional[Session] = None
-        self._aws: Optional[Dict[str, Any]] = None
+        self._session: Session | None = None
+        self._aws: dict[str, Any] | None = None
 
     @property
     def configured(self) -> bool:
@@ -256,7 +257,7 @@ class ThreadSession(threading.local):
         if rasterio.env.hasenv():
             rasterio.env.delenv()
 
-    def session(self, session: Union[Dict[str, Any], Session, None] = None) -> Session:
+    def session(self, session: dict[str, Any] | Session | None = None) -> Session:
         if self._session is None:
             # first call in this thread
             # 1. Start GDAL environment
@@ -295,7 +296,7 @@ def _sanitize(
     return {k: (v if k not in keys else "xx..xx") for k, v in opts.items()}
 
 
-def get_rio_env(sanitize: bool = True, no_session_keys: bool = False) -> Dict[str, Any]:
+def get_rio_env(sanitize: bool = True, no_session_keys: bool = False) -> dict[str, Any]:
     """
     Get GDAL params configured by rasterio for the current thread.
 
@@ -327,7 +328,7 @@ def rio_env(session=None, **kw) -> Env:
 
 
 def _set_default_rio_config(
-    aws: Optional[Dict[str, Any]] = None,
+    aws: dict[str, Any] | None = None,
     cloud_defaults: bool = False,
     **kwargs,
 ) -> None:
@@ -339,7 +340,7 @@ def configure_rio(
     *,
     cloud_defaults: bool = False,
     verbose: bool = False,
-    aws: Optional[Dict[str, Any]] = None,
+    aws: dict[str, Any] | None = None,
     **params,
 ) -> None:
     """
@@ -375,9 +376,9 @@ def _dump_rio_config() -> None:
 
 
 def configure_s3_access(
-    profile: Optional[str] = None,
+    profile: str | None = None,
     region_name: str = "auto",
-    aws_unsigned: Optional[bool] = None,
+    aws_unsigned: bool | None = None,
     requester_pays: bool = False,
     cloud_defaults: bool = True,
     **gdal_opts,
@@ -439,7 +440,7 @@ def _do_read(
     cfg: RasterLoadParams,
     dst_geobox: GeoBox,
     rr: ReprojectInfo,
-    dst: Optional[np.ndarray] = None,
+    dst: np.ndarray | None = None,
 ) -> tuple[tuple[slice, slice], np.ndarray]:
     resampling = resampling_s2rio(cfg.resampling)
     rdr = src.ds
@@ -502,8 +503,8 @@ def rio_read(
     src: RasterSource,
     cfg: RasterLoadParams,
     dst_geobox: GeoBox,
-    dst: Optional[np.ndarray] = None,
-    selection: Optional[ReaderSubsetSelection] = None,
+    dst: np.ndarray | None = None,
+    selection: ReaderSubsetSelection | None = None,
 ) -> tuple[tuple[slice, slice], np.ndarray]:
     """
     Internal read method.
@@ -528,7 +529,7 @@ def rio_read(
     """
     ydim = src.ydim
 
-    def prep_dst(dst: Optional[np.ndarray]) -> Optional[np.ndarray]:
+    def prep_dst(dst: np.ndarray | None) -> np.ndarray | None:
         if dst is None:
             return None
         if dst.ndim == 2 or ydim == 1:
@@ -598,8 +599,8 @@ def _rio_read(
     src: RasterSource,
     cfg: RasterLoadParams,
     dst_geobox: GeoBox,
-    dst: Optional[np.ndarray] = None,
-    selection: Optional[ReaderSubsetSelection] = None,
+    dst: np.ndarray | None = None,
+    selection: ReaderSubsetSelection | None = None,
 ) -> tuple[tuple[slice, slice], np.ndarray]:
     # if resampling is `nearest` then ignore sub-pixel translation when deciding
     # whether we can just paste source into destination
@@ -607,7 +608,7 @@ def _rio_read(
 
     with rasterio.open(src.uri, "r", sharing=False) as rdr:
         assert isinstance(rdr, rasterio.DatasetReader)
-        ovr_idx: Optional[int] = None
+        ovr_idx: int | None = None
 
         bidx = resolve_band_query(src, rdr.count, selection=selection)
         rr = _reproject_info_from_rio(rdr, dst_geobox, ttol=ttol)
@@ -631,7 +632,7 @@ def _rio_read(
                 )
 
 
-def capture_rio_env() -> Dict[str, Any]:
+def capture_rio_env() -> dict[str, Any]:
     # pylint: disable=protected-access
     if _CFG._configured:
         env = {**_CFG._gdal_opts, "_aws": _CFG._aws}

--- a/src/odc/loader/_utils.py
+++ b/src/odc/loader/_utils.py
@@ -2,8 +2,9 @@
 Generic tools with only standard lib dependencies.
 """
 
+from collections.abc import Callable, Iterable, Iterator, Sized
 from concurrent.futures import ThreadPoolExecutor
-from typing import Callable, Iterable, Iterator, Sized, TypeVar, Union
+from typing import TypeVar
 
 from typing_extensions import override
 
@@ -34,7 +35,7 @@ class SizedIterable(Sized, Iterable[T]):
 def pmap(
     func: Callable[[T], S],
     inputs: Iterable[T],
-    pool: Union[ThreadPoolExecutor, int, None],
+    pool: ThreadPoolExecutor | int | None,
 ) -> Iterator[S]:
     """
     Wrapper for ThreadPoolExecutor.map

--- a/src/odc/loader/_zarr.py
+++ b/src/odc/loader/_zarr.py
@@ -6,9 +6,9 @@ from __future__ import annotations
 
 import json
 import math
-from collections.abc import Mapping, Sequence
+from collections.abc import Iterator, Mapping, Sequence
 from contextlib import contextmanager
-from typing import Any, Iterator, TypeAlias
+from typing import Any, TypeAlias
 
 import dask.array as da
 import fsspec
@@ -125,7 +125,7 @@ class Context:
         self.fs = fs
         self.gbt = gbt
 
-    def with_env(self, env: dict[str, Any]) -> "Context":
+    def with_env(self, env: dict[str, Any]) -> Context:
         assert isinstance(env, dict)
         return Context(self.geobox, self.chunks, fs=self.fs)
 

--- a/src/odc/loader/test_builder.py
+++ b/src/odc/loader/test_builder.py
@@ -2,9 +2,10 @@
 # pylint: disable=redefined-outer-name,unused-argument
 from __future__ import annotations
 
+from collections.abc import Mapping, Sequence
 from datetime import datetime
 from types import SimpleNamespace as _sn
-from typing import Any, Dict, Literal, Mapping, Sequence
+from typing import Any, Literal
 
 import dask
 import dask.array as da
@@ -42,7 +43,7 @@ _rlp = RasterLoadParams
 
 def _full_tyx_bins(
     tiles: GeoboxTiles, nsrcs=1, nt=1
-) -> Dict[tuple[int, int, int], list[int]]:
+) -> dict[tuple[int, int, int], list[int]]:
     return {idx: list(range(nsrcs)) for idx in np.ndindex((nt, *tiles.shape.yx))}
 
 
@@ -99,7 +100,7 @@ rlp_fixtures = [
 
 def check_xx(
     xx: Dataset,
-    bands: Dict[str, RasterLoadParams],
+    bands: dict[str, RasterLoadParams],
     extra_coords: Sequence[FixedCoord] | None,
     extra_dims: Mapping[str, int] | None,
     expect: Mapping[str, _sn],
@@ -132,7 +133,7 @@ def check_xx(
 
 @pytest.mark.parametrize("bands,extra_coords,extra_dims,expect", rlp_fixtures)
 def test_mk_dataset(
-    bands: Dict[str, RasterLoadParams],
+    bands: dict[str, RasterLoadParams],
     extra_coords: Sequence[FixedCoord] | None,
     extra_dims: Mapping[str, int] | None,
     expect: Mapping[str, _sn],
@@ -159,7 +160,7 @@ def test_mk_dataset(
 @pytest.mark.parametrize("chunk_extra_dims", [False, True])
 @pytest.mark.parametrize("mode", ["auto", "concurrency"])
 def test_dask_builder(
-    bands: Dict[str, RasterLoadParams],
+    bands: dict[str, RasterLoadParams],
     extra_coords: Sequence[FixedCoord] | None,
     extra_dims: Mapping[str, int] | None,
     expect: Mapping[str, _sn],

--- a/src/odc/loader/test_utils_aws.py
+++ b/src/odc/loader/test_utils_aws.py
@@ -85,7 +85,7 @@ def test_fetch_text() -> None:
         assert _fetch_text("http://localhost:8817") == "text"
 
     def fake_urlopen(*args, **kw):
-        raise IOError("Always broken")
+        raise OSError("Always broken")
 
     with patch_aws("urlopen", fake_urlopen):
         assert _fetch_text("http://localhost:8817") is None

--- a/src/odc/loader/testing/fixtures.py
+++ b/src/odc/loader/testing/fixtures.py
@@ -10,9 +10,10 @@ import pathlib
 import shutil
 import tempfile
 from collections import abc
+from collections.abc import Generator, Iterator
 from contextlib import contextmanager
 from pathlib import Path
-from typing import Any, Generator, Iterator, Optional
+from typing import Any
 
 import numpy as np
 import rasterio
@@ -142,7 +143,7 @@ class LoadState:
         self.meta = meta
         self.finalised = False
 
-    def with_env(self, env: dict[str, Any]) -> "LoadState":
+    def with_env(self, env: dict[str, Any]) -> LoadState:
         assert isinstance(env, dict)
         return LoadState(self.geobox, self.meta)
 
@@ -164,8 +165,8 @@ class FakeReader:
         cfg: RasterLoadParams,
         dst_geobox: GeoBox,
         *,
-        dst: Optional[np.ndarray] = None,
-        selection: Optional[ReaderSubsetSelection] = None,
+        dst: np.ndarray | None = None,
+        selection: ReaderSubsetSelection | None = None,
     ) -> tuple[tuple[slice, slice], np.ndarray]:
         meta = self._src.meta
         assert meta is not None

--- a/src/odc/loader/types.py
+++ b/src/odc/loader/types.py
@@ -3,11 +3,11 @@
 from __future__ import annotations
 
 import json
+from contextlib import AbstractContextManager
 from dataclasses import astuple, dataclass, field, replace
 from typing import (
     Any,
     Callable,
-    ContextManager,
     Dict,
     Mapping,
     Protocol,
@@ -739,7 +739,7 @@ class ReaderDriver(Protocol):
 
     def restore_env(
         self, env: dict[str, Any], load_state: GlobalLoadContext
-    ) -> ContextManager[LocalLoadContext]: ...
+    ) -> AbstractContextManager[LocalLoadContext]: ...
 
     def open(self, src: RasterSource, ctx: LocalLoadContext) -> RasterReader: ...
 

--- a/src/odc/loader/types.py
+++ b/src/odc/loader/types.py
@@ -3,19 +3,10 @@
 from __future__ import annotations
 
 import json
+from collections.abc import Callable, Mapping, Sequence
 from contextlib import AbstractContextManager
 from dataclasses import astuple, dataclass, field, replace
-from typing import (
-    Any,
-    Callable,
-    Dict,
-    Mapping,
-    Protocol,
-    Sequence,
-    Tuple,
-    TypeAlias,
-    TypeVar,
-)
+from typing import Any, Protocol, TypeAlias, TypeVar
 
 import numpy as np
 import xarray as xr
@@ -25,7 +16,7 @@ from odc.geo.geobox import GeoBox, GeoBoxBase
 
 T = TypeVar("T")
 
-BandKey: TypeAlias = Tuple[str, int]
+BandKey: TypeAlias = tuple[str, int]
 """Asset Name, band index within an asset (1 based, 0 indicates "all the bands")."""
 
 BandIdentifier: TypeAlias = str | BandKey
@@ -67,7 +58,7 @@ class RasterBandMetadata:
     units: str = "1"
     """Units of the pixel data."""
 
-    dims: Tuple[str, ...] = ()
+    dims: tuple[str, ...] = ()
     """Dimension names for this band.
 
     e.g. ("y", "x", "wavelength")
@@ -79,7 +70,7 @@ class RasterBandMetadata:
     attrs: dict[str, Any] = field(default_factory=dict)
     """Additional raster band attributes."""
 
-    def with_defaults(self, defaults: "RasterBandMetadata") -> "RasterBandMetadata":
+    def with_defaults(self, defaults: RasterBandMetadata) -> RasterBandMetadata:
         """
         Merge with another metadata object, using self as the primary source.
 
@@ -94,7 +85,7 @@ class RasterBandMetadata:
             attrs=with_default(self.attrs, defaults.attrs),
         )
 
-    def patch(self, **kwargs) -> "RasterBandMetadata":
+    def patch(self, **kwargs) -> RasterBandMetadata:
         """
         Return a new object with updated fields.
         """
@@ -103,7 +94,7 @@ class RasterBandMetadata:
     def __dask_tokenize__(self):
         return astuple(self)
 
-    def _repr_json_(self) -> Dict[str, Any]:
+    def _repr_json_(self) -> dict[str, Any]:
         """
         Return a JSON serializable representation of the RasterBandMetadata object.
         """
@@ -168,7 +159,7 @@ class AuxBandMetadata:
     units: str = "1"
     """Units of the data."""
 
-    dims: Tuple[str, ...] = ()
+    dims: tuple[str, ...] = ()
     """Dimension names for this auxilliary band.
 
     e.g. ("time",) or ("index",) or ()
@@ -180,7 +171,7 @@ class AuxBandMetadata:
     attrs: dict[str, Any] = field(default_factory=dict)
     """Additional auxilliary band attributes."""
 
-    def _repr_json_(self) -> Dict[str, Any]:
+    def _repr_json_(self) -> dict[str, Any]:
         """
         Return a JSON serializable representation of the AuxBandMetadata object.
         """
@@ -231,7 +222,7 @@ class FixedCoord:
         if not self.dim:
             self.dim = self.name
 
-    def _repr_json_(self) -> Dict[str, Any]:
+    def _repr_json_(self) -> dict[str, Any]:
         """
         Return a JSON serializable representation of the FixedCoord object.
         """
@@ -279,13 +270,13 @@ class RasterGroupMetadata:
     Must be same values across items/datasets.
     """
 
-    def patch(self, **kwargs) -> "RasterGroupMetadata":
+    def patch(self, **kwargs) -> RasterGroupMetadata:
         """
         Return a new object with updated fields.
         """
         return replace(self, **kwargs)
 
-    def merge(self, other: "RasterGroupMetadata") -> "RasterGroupMetadata":
+    def merge(self, other: RasterGroupMetadata) -> RasterGroupMetadata:
         """
         Merge with another metadata object, using self as the primary source.
         """
@@ -299,7 +290,7 @@ class RasterGroupMetadata:
 
         return RasterGroupMetadata(bands, aliases, extra_dims, tuple(extra_coords))
 
-    def _repr_json_(self) -> Dict[str, Any]:
+    def _repr_json_(self) -> dict[str, Any]:
         """
         Return a JSON serializable representation of the RasterGroupMetadata object.
         """
@@ -367,13 +358,13 @@ class RasterSource:
     driver_data: Any = None
     """IO Driver specific extra data."""
 
-    def patch(self, **kwargs) -> "RasterSource":
+    def patch(self, **kwargs) -> RasterSource:
         """
         Return a new object with updated fields.
         """
         return replace(self, **kwargs)
 
-    def strip(self) -> "RasterSource":
+    def strip(self) -> RasterSource:
         """
         Copy with minimal data only.
 
@@ -398,7 +389,7 @@ class RasterSource:
     def __dask_tokenize__(self) -> tuple[str, int, str | None]:
         return (self.uri, self.band, self.subdataset)
 
-    def _repr_json_(self) -> Dict[str, Any]:
+    def _repr_json_(self) -> dict[str, Any]:
         """
         Return a JSON serializable representation of the RasterSource object.
         """
@@ -448,13 +439,13 @@ class AuxDataSource:
     driver_data: Any = None
     """IO Driver specific extra data."""
 
-    def patch(self, **kwargs) -> "AuxDataSource":
+    def patch(self, **kwargs) -> AuxDataSource:
         """
         Return a new object with updated fields.
         """
         return replace(self, **kwargs)
 
-    def strip(self) -> "AuxDataSource":
+    def strip(self) -> AuxDataSource:
         """
         Compatibility with RasterSource.strip()
         """
@@ -509,7 +500,7 @@ class RasterLoadParams:
     fail_on_error: bool = True
     """Quit on the first error or continue."""
 
-    dims: Tuple[str, ...] = ()
+    dims: tuple[str, ...] = ()
     """Dimension names for this band."""
 
     meta: RasterBandMetadata | None = None
@@ -518,7 +509,7 @@ class RasterLoadParams:
     fuser_fqn: str | None = None
     """Fully qualified name of custom fuser function to use for this band."""
 
-    def patch(self, **kwargs) -> "RasterLoadParams":
+    def patch(self, **kwargs) -> RasterLoadParams:
         """
         Return a new object with updated fields.
         """
@@ -537,7 +528,7 @@ class RasterLoadParams:
         return _extra_dims(self.dims)
 
     @staticmethod
-    def same_as(src: RasterBandMetadata | RasterSource) -> "RasterLoadParams":
+    def same_as(src: RasterBandMetadata | RasterSource) -> RasterLoadParams:
         """Construct from source object."""
         if isinstance(src, RasterBandMetadata):
             meta = src
@@ -560,7 +551,7 @@ class RasterLoadParams:
     def __dask_tokenize__(self):
         return astuple(self)
 
-    def _repr_json_(self) -> Dict[str, Any]:
+    def _repr_json_(self) -> dict[str, Any]:
         """
         Return a JSON serializable representation of the RasterLoadParams object.
         """
@@ -594,14 +585,14 @@ class AuxLoadParams:
     meta: AuxBandMetadata | None = None
     """Expected auxiliary band metadata."""
 
-    def patch(self, **kwargs) -> "AuxLoadParams":
+    def patch(self, **kwargs) -> AuxLoadParams:
         """
         Return a new object with updated fields.
         """
         return replace(self, **kwargs)
 
     @staticmethod
-    def same_as(src: AuxBandMetadata | AuxDataSource) -> "AuxLoadParams":
+    def same_as(src: AuxBandMetadata | AuxDataSource) -> AuxLoadParams:
         """Construct from source object."""
         if isinstance(src, AuxBandMetadata):
             meta = src
@@ -617,7 +608,7 @@ class AuxLoadParams:
     def __dask_tokenize__(self):
         return astuple(self)
 
-    def _repr_json_(self) -> Dict[str, Any]:
+    def _repr_json_(self) -> dict[str, Any]:
         """
         Return a JSON serializable representation of the AuxLoadParams object.
         """
@@ -689,7 +680,7 @@ class DaskRasterReader(Protocol):
         *,
         layer_name: str,
         idx: int,
-    ) -> "DaskRasterReader": ...
+    ) -> DaskRasterReader: ...
 
 
 class AuxReader(Protocol):
@@ -730,7 +721,7 @@ class ReaderDriver(Protocol):
         self,
         geobox: GeoBox,
         *,
-        chunks: None | Dict[str, int] = None,
+        chunks: None | dict[str, int] = None,
     ) -> GlobalLoadContext: ...
 
     def finalise_load(self, load_state: GlobalLoadContext) -> Any: ...
@@ -828,7 +819,7 @@ def norm_key(k: BandIdentifier) -> BandKey:
     return k
 
 
-def _ydim(dims: Tuple[str, ...]) -> int:
+def _ydim(dims: tuple[str, ...]) -> int:
     if dims:
         return dims.index("y")
     return 0


### PR DESCRIPTION
A lot of the names from typing are
no longer required, so remove them,
and make some other updates for
Python 3.10. Also enable the Ruff
UP-rules so these migrations can
be done automatically in the future.