### PR TITLE
CI: test with Python 3.14

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,7 +39,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
         dask-version: ["dask<2025.01", "dask>=2025.01"]
       fail-fast: false
     defaults:


### PR DESCRIPTION
Ubuntu 26.04 is released and
comes with Python 3.14, so add
that to the test matrix.